### PR TITLE
edit to one of the cuts

### DIFF
--- a/src/main/java/org/jlab/jnp/grapes/services/EPGammaWagon.java
+++ b/src/main/java/org/jlab/jnp/grapes/services/EPGammaWagon.java
@@ -139,7 +139,7 @@ public class EPGammaWagon extends BeamTargetWagon {
                                             && missAll.mass2() > -0.1 &&  missAll.mass2() < 0.1
                                             && missAll.px()*missAll.px() + missAll.py()*missAll.py() < 1.0
                                             && eta.mass()>0.05 && eta.mass()<1.0
-                                            && Vangle( eta.vector().vect() , eta.vector().vect() ) < 7.5
+                                            && Vangle( eta.vector().vect() , missEta.vector().vect() ) < 7.5
                                             ;
                                 }
                             }


### PR DESCRIPTION
changed Vangle( eta.vector().vect() , eta.vector().vect() ) < 7.5 
to Vangle( eta.vector().vect() , missEta.vector().vect() ) < 7.5
issue was that angle was being calculated to itself (invariant mass of eta) rather than between the invariant mass and the missing mass